### PR TITLE
remove shopify

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ Remote LATAM lists U.S. and high-income companies with remote tech jobs in [Lati
 - Nirvana [Open Positions](https://www.nirvanatech.com/careers)
 - Quinncia [Open Positions](https://wellfound.com/company/quinncia/jobs)
 - Remote [Open Positions](https://remote.com/careers)
-- Shopify [Open Positions](https://www.shopify.com/careers/)
 - SOAX [Open Positions](https://soax.com/careers)
 - Sticker Mule [Open Positions](https://www.stickermule.com/careers)
 - Supabase [Open Positions](https://supabase.com/careers)


### PR DESCRIPTION
I'm not sure anymore if the available roles are available for LATAM.

From https://jobs.rubyonrails.org/jobs/323 it says: "Remote, Americas", but from comments from different sources, it seems it is only US.

I'll remove it until new evidence 😄 